### PR TITLE
Support passing handleReturn

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,8 +11,9 @@ function normalizeSelectedIndex(selectedIndex, max) {
 
 /**
  * Props:
- * - typeaheadToken?: string
  * - editorRef?: Function
+ * - handleReturn?: Function
+ * - typeaheadToken?: string
  */
 
 class TypeaheadEditor extends Editor {
@@ -164,6 +165,9 @@ class TypeaheadEditor extends Editor {
         );
       }
       return true;
+    }
+    if (this.props.handleReturn) {
+      return this.props.handleReturn();
     }
     return false;
   };


### PR DESCRIPTION
- Let the parent component pass `handleReturn` to listen for the Enter key press event. This can be useful for example if you want to prevent creating new lines, that could be done simply by passing a function that returns true.